### PR TITLE
update to rollup-plugin-postcss 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 rollup-plugin-postcss-modules
 =============================
 
-Using `rollup-plugin-postcss` with [`postcss-modules`](https://github.com/css-modules/postcss-modules) is easy, but there’s only one way to combine them. Also, until [this PR](https://github.com/egoist/rollup-plugin-postcss/pull/127) is merged, there’s no way to use `rollup-plugin-postcss>=1.0` with Typescript.
+Use the option `modules: { ... }` to pass [options](https://github.com/css-modules/postcss-modules#usage)
+to the [`postcss-modules`](https://github.com/css-modules/postcss-modules) plugin.
 
-Just add some regular PostCSS plugins and be on your way.
+With `rollup-plugin-postcss` 2.0, the only continued advantage this one has is TypeScript support.
 
-Two new options exist:
+One new option exists:
 
 * `writeDefinitions: true` creates `.css.d.ts` files next to every processed `.css` file.
-* `modules: { ... }` can be used to pass [options](https://github.com/css-modules/postcss-modules#usage) to the intrinsic `postcss-modules` plugin.
 
 Example
 -------

--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ One new option exists:
 
 * `writeDefinitions: true` creates `.css.d.ts` files next to every processed `.css` file.
 
+Also the default `namedExports` option is slightly different:
+
+* `.class-name { ... } .switch { ... }` gets converted to something like
+
+    ```typescript
+	export const className = 'class-name'
+	export const $switch$ = 'switch'
+	export default {
+		'class-name': 'class-name',
+		className: 'class-name',
+		'switch': 'switch',
+		$switch$: 'switch',
+	}
+	```
+
 Example
 -------
 

--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ import * as postcssModules from 'postcss-modules'
 
 // eslint-disable-next-line import/no-extraneous-dependencies, no-unused-vars
 import { Plugin } from 'rollup'
-// eslint-disable-next-line import/no-extraneous-dependencies
+// eslint-disable-next-line import/no-extraneous-dependencies, no-unused-vars
 import { Transformer } from 'postcss'
 
 const formatCSSDefinition = (name: string, classNames: string[]) => `\
@@ -61,8 +61,6 @@ class CSSExports {
 export interface Options extends postcss.Options {
 	/** Write typescript definitions next to source files? Default: false */
 	writeDefinitions?: boolean | DefinitionCB
-	/** Options for postcss-modules. */
-	modules?: postcssModules.Options
 }
 
 export default function eslintPluginPostCSSModules(options: Options = {}): Promise<Plugin> {
@@ -79,16 +77,16 @@ export default function eslintPluginPostCSSModules(options: Options = {}): Promi
 	if (plugins.some(p => (p as Transformer).postcssPlugin === 'postcss-modules')) {
 		throw new Error("'rollup-plugin-postcss-modules' provides a 'postcss-modules' plugin, you cannot specify your own. Use the `modules` config key for configuration.")
 	}
-	if (modules === false || modules.getJSON) {
+	const modulesOptions = modules === true ? {} : modules
+	if (modulesOptions === false || modulesOptions.getJSON) {
 		throw new Error("'rollup-plugin-postcss-modules' provides a 'postcss-modules' plugin and its `getJSON()`. You cannot specify `modules.getJSON`")
 	}
 	
 	const { getExport, getJSON } = new CSSExports(writeDefinitions)
-	
-	const postcssModulesPlugin = postcssModules({ getJSON, ...modules })
-	
+		
 	return postcss({
-		plugins: [postcssModulesPlugin, ...plugins],
+		plugins: [...plugins],
+		modules: { getJSON, ...modulesOptions },
 		getExport,
 		...rest,
 	})

--- a/index.ts
+++ b/index.ts
@@ -4,20 +4,28 @@ import * as path from 'path'
 import * as camelcase from 'camelcase'
 import * as postcss from 'rollup-plugin-postcss'
 import * as postcssModules from 'postcss-modules'
+import * as reserved from 'reserved-words'
 
 // eslint-disable-next-line import/no-extraneous-dependencies, no-unused-vars
 import { Plugin } from 'rollup'
 // eslint-disable-next-line import/no-extraneous-dependencies, no-unused-vars
 import { Transformer } from 'postcss'
 
-const formatCSSDefinition = (name: string, classNames: string[]) => `\
-declare namespace ${name} {
-	${classNames.map(t => `const ${t}: string`).join('\n\t')}
+function fixname(name: string) {
+	const ccName = camelcase(name)
+	return reserved.check(ccName) ? `$${ccName}$` : ccName
 }
+
+const formatCSSDefinition = (name: string, classNames: string[]) => `\
+${classNames.filter(n => !/-/.test(n)).map(t => `export const ${t}: string`).join('\n')}
+interface Namespace {
+	${classNames.map(t => `${JSON.stringify(t)}: string,`).join('\n\t')}
+}
+const ${name}: Namespace
 export default ${name}`
 
 async function writeCSSDefinition(cssPath: string, classNames: string[]): Promise<string> {
-	const name = camelcase(path.basename(cssPath, '.css'))
+	const name = fixname(path.basename(cssPath, '.css'))
 	const definition = formatCSSDefinition(name, classNames)
 	const dPath = `${cssPath}.d.ts`
 	await fs.writeFile(dPath, `${definition}\n`)
@@ -32,7 +40,6 @@ class CSSExports {
 	
 	constructor(writeDefinitions: boolean | DefinitionCB) {
 		this.writeDefinitions = writeDefinitions
-		this.exports = {}
 	}
 	
 	definitionCB = async (dPath: string) => {
@@ -46,16 +53,14 @@ class CSSExports {
 	getJSON = async (id: string, exportTokens: postcssModules.ExportTokens) => {
 		const ccTokens: postcssModules.ExportTokens = {}
 		for (const className of Object.keys(exportTokens)) {
-			ccTokens[camelcase(className)] = exportTokens[className]
+			ccTokens[fixname(className)] = exportTokens[className]
+			ccTokens[className] = exportTokens[className]
 		}
 		if (this.writeDefinitions) {
 			const dPath = await writeCSSDefinition(id, Object.keys(ccTokens))
 			await this.definitionCB(dPath)
 		}
-		this.exports[id] = ccTokens
 	}
-	
-	getExport = (id: string) => this.exports[id]
 }
 
 export interface Options extends postcss.Options {
@@ -69,10 +74,11 @@ export default function eslintPluginPostCSSModules(options: Options = {}): Promi
 		// own options
 		writeDefinitions = false,
 		modules = {},
+		namedExports = fixname,
 		...rest
 	} = options
 	if (rest.getExport) {
-		throw new Error("rollup-plugin-postcss-modules' provides getExport, you cannot specify your own.")
+		throw new Error("'getExport' is no longer supported.")
 	}
 	if (plugins.some(p => (p as Transformer).postcssPlugin === 'postcss-modules')) {
 		throw new Error("'rollup-plugin-postcss-modules' provides a 'postcss-modules' plugin, you cannot specify your own. Use the `modules` config key for configuration.")
@@ -82,12 +88,12 @@ export default function eslintPluginPostCSSModules(options: Options = {}): Promi
 		throw new Error("'rollup-plugin-postcss-modules' provides a 'postcss-modules' plugin and its `getJSON()`. You cannot specify `modules.getJSON`")
 	}
 	
-	const { getExport, getJSON } = new CSSExports(writeDefinitions)
+	const { getJSON } = new CSSExports(writeDefinitions)
 		
 	return postcss({
 		plugins: [...plugins],
 		modules: { getJSON, ...modulesOptions },
-		getExport,
+		namedExports,
 		...rest,
 	})
 }

--- a/package.json
+++ b/package.json
@@ -16,32 +16,32 @@
     "ava": "ava"
   },
   "devDependencies": {
-    "@types/acorn": "^4.0.3",
+    "@types/acorn": "^4.0.4",
     "@types/camelcase": "^4.1.0",
     "@types/mz": "^0.0.32",
-    "@types/node": "^10.11.3",
+    "@types/node": "^10.12.18",
     "@types/source-map": "^0.5.7",
-    "aurelia-logging": "^1.5.0",
-    "ava": "^0.25.0",
+    "aurelia-logging": "^1.5.1",
+    "ava": "^1.1.0",
     "ava-fixture": "^0.11.0",
-    "eslint": "^3.19.0",
-    "eslint-config-airbnb": "^14.1.0",
-    "eslint-config-flying-sheep": "^3.0.2",
-    "eslint-plugin-import": "^2.14.0",
-    "eslint-plugin-jsx-a11y": "^4.0.0",
+    "eslint": "^5.12.1",
+    "eslint-config-airbnb": "^17.1.0",
+    "eslint-config-flying-sheep": "^5.2.0",
+    "eslint-plugin-import": "^2.15.0",
+    "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-no-foreach": "^1.0.0",
-    "eslint-plugin-react": "^6.10.3",
-    "eslint-plugin-typescript": "^0.7.0",
+    "eslint-plugin-react": "^7.12.4",
+    "eslint-plugin-typescript": "^0.14.0",
     "mkdirp-promise": "^5.0.1",
     "rmfr": "^2.0.0",
-    "rollup": "^0.66.2",
-    "typescript": "^3.1.1",
-    "typescript-eslint-parser": "^19.0.2"
+    "rollup": "^1.1.2",
+    "typescript": "^3.2.4",
+    "typescript-eslint-parser": "^22.0.0"
   },
   "dependencies": {
     "camelcase": "^5.0.0",
     "mz": "^2.7.0",
     "postcss-modules": "^1.4.1",
-    "rollup-plugin-postcss": "0.5.6"
+    "rollup-plugin-postcss": "^2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,32 +16,35 @@
     "ava": "ava"
   },
   "devDependencies": {
-    "@types/acorn": "^4.0.4",
+    "@types/acorn": "^4.0.5",
     "@types/camelcase": "^4.1.0",
     "@types/mz": "^0.0.32",
-    "@types/node": "^10.12.18",
+    "@types/node": "^11.9.4",
     "@types/source-map": "^0.5.7",
     "aurelia-logging": "^1.5.1",
-    "ava": "^1.1.0",
+    "ava": "^1.2.1",
     "ava-fixture": "^0.11.0",
-    "eslint": "^5.12.1",
+    "eslint": "^5.13.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-flying-sheep": "^5.2.0",
-    "eslint-plugin-import": "^2.15.0",
-    "eslint-plugin-jsx-a11y": "^6.1.2",
+    "eslint-plugin-import": "^2.16.0",
+    "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-no-foreach": "^1.0.0",
     "eslint-plugin-react": "^7.12.4",
     "eslint-plugin-typescript": "^0.14.0",
     "mkdirp-promise": "^5.0.1",
     "rmfr": "^2.0.0",
     "rollup": "^1.1.2",
-    "typescript": "^3.2.4",
+    "rollup-plugin-external-globals": "^0.2.1",
+    "typescript": "^3.3.3",
     "typescript-eslint-parser": "^22.0.0"
   },
   "dependencies": {
     "camelcase": "^5.0.0",
     "mz": "^2.7.0",
     "postcss-modules": "^1.4.1",
-    "rollup-plugin-postcss": "^2.0"
+    "reserved-words": "^0.1.2",
+    "rollup-plugin-postcss": "^2.0.3",
+    "ts-diagnostic-formatter": "^0.1.1"
   }
 }

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -5,7 +5,11 @@ import rmfr from 'rmfr'
 import ava from 'ava'
 import fixture from 'ava-fixture'
 
+import ts from 'typescript'
+import format from 'ts-diagnostic-formatter'
+
 import { rollup } from 'rollup'
+import externalGlobals from 'rollup-plugin-external-globals'
 import postcss from '..'
 
 const styleInjectPath = require
@@ -13,21 +17,34 @@ const styleInjectPath = require
 	.replace(/[\\/]+/g, '/')
 const ftest = fixture(ava, 'test/fixtures/cases', 'test/fixtures/expected', 'test/fixtures/results')
 
-ftest.each(async (t, { casePath, resultPath, match }) => { try {
+ftest.each(async (t, { casePath, baselinePath, resultPath, match }) => { try {
 	await rmfr(resultPath)
 	await mkdirp(resultPath)
+	
+	const definition = `${baselinePath}/in.css.d.ts`
+	if (await fs.exists(definition)) {
+		const parsed = ts.createSourceFile(
+			definition,
+			(await fs.readFile(definition)).toString(),
+			ts.ScriptTarget.ES2015,
+		)
+		if (parsed.parseDiagnostics.length !== 0) {
+			const prog = ts.createProgram([definition], {})
+			const err = format(prog.getSyntacticDiagnostics(parsed), 'codeframe')[0]
+			t.fail(`Syntax error in ${err.file}\n${err.message}`)
+		}
+	}
 	
 	const opts = require(`${casePath}/options`)
 	const options = typeof opts === 'function' ? opts(resultPath) : opts
 	
 	const bundle = await rollup({
 		input: `${casePath}/in.css`,
-		output: {
-			file: `${resultPath}/out.js`,
-			globals: { [styleInjectPath]: 'styleInject' },
-		},
-		external: [styleInjectPath],
-		plugins: [await postcss(options)],
+		output: { file: `${resultPath}/out.js` },
+		plugins: [
+			await postcss(options),
+			externalGlobals({ [styleInjectPath]: 'styleInject' }),
+		],
 	})
 	
 	await bundle.write({

--- a/test/fixtures/expected/camelcase/in.css.d.ts
+++ b/test/fixtures/expected/camelcase/in.css.d.ts
@@ -1,4 +1,7 @@
-declare namespace in {
-	const testCls: string
+export const testCls: string
+interface Namespace {
+	"testCls": string,
+	"test-cls": string,
 }
-export default in
+const $in$: Namespace
+export default $in$

--- a/test/fixtures/expected/camelcase/out.js
+++ b/test/fixtures/expected/camelcase/out.js
@@ -1,4 +1,8 @@
-__$styleInject(".test-cls { color: blue }", {});
-var _in = {"testCls":"test-cls"};
+var testCls = "test-cls";
+var css = ".test-cls { color: blue }";
+var _in = {"test-cls":"test-cls","testCls":"test-cls"};
+
+styleInject(css);
 
 export default _in;
+export { testCls };

--- a/test/fixtures/expected/definitions/in.css.d.ts
+++ b/test/fixtures/expected/definitions/in.css.d.ts
@@ -1,4 +1,6 @@
-declare namespace in {
-	const test: string
+export const test: string
+interface Namespace {
+	"test": string,
 }
-export default in
+const $in$: Namespace
+export default $in$

--- a/test/fixtures/expected/definitions/out.js
+++ b/test/fixtures/expected/definitions/out.js
@@ -1,4 +1,8 @@
-__$styleInject(".test { color: blue }", {});
+var test = "test";
+var css = ".test { color: blue }";
 var _in = {"test":"test"};
 
+styleInject(css);
+
 export default _in;
+export { test };

--- a/test/fixtures/expected/passthrough/out.js
+++ b/test/fixtures/expected/passthrough/out.js
@@ -1,4 +1,8 @@
-__$styleInject(".test { color: blue }", {});
+var test = "test";
+var css = ".test { color: blue }";
 var _in = {"test":"test"};
 
+styleInject(css);
+
 export default _in;
+export { test };

--- a/typings/postcss-modules.d.ts
+++ b/typings/postcss-modules.d.ts
@@ -14,8 +14,11 @@ declare namespace postcssModules {
 			Promise<{ injectableSource: string, exportTokens: ExportTokens }>
 	}
 	interface Options {
-		/** By default, a JSON file with exported classes will be placed next to corresponding CSS. Use getJSON to do something else. */
-		getJSON?: (cssFileName: string, exportTokens: ExportTokens) => void
+		/**
+		 * By default, a JSON file with exported classes will be placed next to corresponding CSS.
+		 * Use getJSON to do something else.
+		 */
+		getJSON?: (cssFileName: string, exportTokens: ExportTokens) => void | Promise<void>
 		/** By default, the plugin assumes that all the classes are local */
 		scopeBehaviour?: 'local' | 'global'
 		/** Paths to global modules */

--- a/typings/reserved-words.d.ts
+++ b/typings/reserved-words.d.ts
@@ -1,0 +1,1 @@
+export function check(name: string): boolean

--- a/typings/rollup-plugin-postcss.d.ts
+++ b/typings/rollup-plugin-postcss.d.ts
@@ -2,21 +2,33 @@
 
 import { Plugin } from 'rollup'
 import { AcceptedPlugin, Parse, Syntax } from 'postcss'
+import * as postcssModules from 'postcss-modules'
 
 declare namespace rollupPostcss {
+	// eslint-disable-next-line import/prefer-default-export
 	export interface Options {
 		/** Array of postcss plugins to use. Default: none */
 		plugins?: AcceptedPlugin[]
 		/** create a source map? Default: false */
 		sourceMap?: boolean
-		/** If true, extract to the same name as Rollup’s dest (with a .css suffix). Alternatively provide a path or do not extract (The default: false) */
+		/** Inject CSS into `<head>`, it's always false when `extract: true`. */
+		inject?: boolean | { insertAt?: 'top' }
+		/**
+		 * If true, extract to the same name as Rollup’s dest (with a .css suffix).
+		 * Alternatively provide a path or do not extract (The default: false)
+		 */
 		extract?: boolean | string
 		/** When injecting CSS (!extract), should only one `<style/>` tag be created? Default: false */
 		combineStyleTags?: boolean
 		/** Accepted extension to try and parse. Default: .css and .sss */
 		extensions?: string[]
-		/** Function that accepts a input CSS filename and returns a mapping from class name to scoped name. */
+		/**
+		 * Function that accepts a input CSS filename and returns
+		 * a mapping from class name to scoped name.
+		 */
 		getExport?: (id: string) => { [className: string]: string }
+		/** Options for postcss-modules. */
+		modules?: boolean | postcssModules.Options
 		/** Custom CSS parser. */
 		parser?: Parse | Syntax
 		/** CSS preprocessor for alternative syntaxes like Stylus and Sass. */

--- a/typings/rollup-plugin-postcss.d.ts
+++ b/typings/rollup-plugin-postcss.d.ts
@@ -27,6 +27,8 @@ declare namespace rollupPostcss {
 		 * a mapping from class name to scoped name.
 		 */
 		getExport?: (id: string) => { [className: string]: string }
+		/** Use named exports alongside default export. */
+		namedExports?: boolean | ((id: string) => string)
 		/** Options for postcss-modules. */
 		modules?: boolean | postcssModules.Options
 		/** Custom CSS parser. */


### PR DESCRIPTION
WIP. Fixes #7.

Currently stuck on making the test fixtures smaller: Previously I avoided copy/pasting the `style-inject` code into the fixture files by deleting `plugin.intro`, now `rollup-plugin-postcss` simply lets `rollup` insert the code for `styleInjectPath` by doing

```js
output += `import styleInject from ${styleInjectPath}`
```

I want to make rollup not insert that code by specifying `external` and `globals` (pretty much exactly as in the second [`output.globals` example](https://rollupjs.org/guide/en#output-globals)). Specifying `external: [styleInjectPath]` works (i.e. I could shrink the files a bit as-is), but `globals` somehow doesn’t, and I have no idea why.

```js
rollup({
	output: {
		...,
	 	globals: { [styleInjectPath]: 'styleInject' },
	},
 	external: [styleInjectPath],
}
```