### PR TITLE
Fix TS warnings in d.ts files due to missing `declare` before `const`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,7 +21,7 @@ ${classNames.filter(n => !/-/.test(n)).map(t => `export const ${t}: string`).joi
 interface Namespace {
 	${classNames.map(t => `${JSON.stringify(t)}: string,`).join('\n\t')}
 }
-const ${name}: Namespace
+declare const ${name}: Namespace
 export default ${name}`
 
 async function writeCSSDefinition(cssPath: string, classNames: string[]): Promise<string> {

--- a/test/fixtures/expected/camelcase/in.css.d.ts
+++ b/test/fixtures/expected/camelcase/in.css.d.ts
@@ -3,5 +3,5 @@ interface Namespace {
 	"testCls": string,
 	"test-cls": string,
 }
-const $in$: Namespace
+declare const $in$: Namespace
 export default $in$

--- a/test/fixtures/expected/definitions/in.css.d.ts
+++ b/test/fixtures/expected/definitions/in.css.d.ts
@@ -2,5 +2,5 @@ export const test: string
 interface Namespace {
 	"test": string,
 }
-const $in$: Namespace
+declare const $in$: Namespace
 export default $in$


### PR DESCRIPTION
![screen shot 2019-02-19 at 7 54 25 pm](https://user-images.githubusercontent.com/3535127/53061004-ffe2f400-3481-11e9-9e78-723a82517790.png)

Copied the above straight from one of the test files into my editor, and the built in tslint in vscode complains whenever I open it. The fix is just to add `declare` in front of the const namespace line, which shouldn't (far as I know) change any functionality, since top level declarations without `declare` shouldn't be allowed anyway.

[Official-ish link to docs stating that declare is required in d.ts files](https://basarat.gitbooks.io/typescript/docs/types/ambient/d.ts.html)