### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
 	"main": "index.js",
 	"typings": "index.d.ts",
 	"repository": "https://github.com/flying-sheep/rollup-plugin-postcss-modules.git",
+	"homepage": "https://github.com/flying-sheep/rollup-plugin-postcss-modules#readme",
+	"bugs": {
+		"url": "https://github.com/flying-sheep/rollup-plugin-postcss-modules/issues"
+	},
 	"author": "Philipp A.",
 	"license": "GPL-3.0",
 	"scripts": {


### PR DESCRIPTION
## Summary

- add `homepage` metadata pointing to the repository README
- add `bugs.url` metadata pointing to the GitHub issue tracker

## Verification

- `node -e "const p=require('./package.json'); console.log(JSON.stringify({name:p.name,version:p.version,repository:p.repository,bugs:p.bugs,homepage:p.homepage,license:p.license}, null, 2)); if (p.bugs?.url !== 'https://github.com/flying-sheep/rollup-plugin-postcss-modules/issues' || p.homepage !== 'https://github.com/flying-sheep/rollup-plugin-postcss-modules#readme') process.exit(1)"`
- `git diff --check`
- `npm pack --dry-run --json`

This is an AI-assisted metadata cleanup.
